### PR TITLE
amended zc diffs

### DIFF
--- a/R/maxdiff-estimate.R
+++ b/R/maxdiff-estimate.R
@@ -172,8 +172,8 @@ md.hb <- function(md.define,
 
   library(matrixStats)
   # total spread btw Min & Max across all attributes (step #2 from URL)
-  cmr.beta.zc.sumdiffs <- sum(colMaxs(as.matrix(cmr.beta.zc))-colMins(as.matrix(cmr.beta.zc)))
-  cmr.beta.zc.mult     <- (100*md.define$md.item.k) / cmr.beta.zc.sumdiffs   # multiplier to rescale (step #3)
+  cmr.beta.zc.sumdiffs <- max(cmr.beta.zc)-min(cmr.beta.zc)
+  cmr.beta.zc.mult     <- 100/ cmr.beta.zc.sumdiffs   # multiplier to rescale (step #3)
 
   # now recale the zero-centered utilities to that 100 pt scale
   cmr.beta.zc <- cmr.beta.zc * cmr.beta.zc.mult     # (step #4 from URL)

--- a/R/maxdiff-estimate.R
+++ b/R/maxdiff-estimate.R
@@ -173,7 +173,7 @@ md.hb <- function(md.define,
   library(matrixStats)
   # total spread btw Min & Max across all attributes (step #2 from URL)
   cmr.beta.zc.sumdiffs <- sum(colMaxs(as.matrix(cmr.beta.zc))-colMins(as.matrix(cmr.beta.zc)))
-  cmr.beta.zc.mult     <- 100 / cmr.beta.zc.sumdiffs   # multiplier to rescale (step #3)
+  cmr.beta.zc.mult     <- (100*md.define$md.item.k) / cmr.beta.zc.sumdiffs   # multiplier to rescale (step #3)
 
   # now recale the zero-centered utilities to that 100 pt scale
   cmr.beta.zc <- cmr.beta.zc * cmr.beta.zc.mult     # (step #4 from URL)


### PR DESCRIPTION
Step 3 in https://sawtoothsoftware.com/forum/6140/is-there-a-formula-for-calculating-the-zero-centered-diffs  seems to suggest multiplying 100 by the number of items before dividing by the sum of zc beta differences. Updated code to reflect this calculation. 